### PR TITLE
fix: disable thinking in analyze-prompt for Haiku compatibility

### DIFF
--- a/src/lib/prompt-analyzer.ts
+++ b/src/lib/prompt-analyzer.ts
@@ -355,11 +355,16 @@ Respond with JSON only, no explanation.`;
       const tempAnalysisDir = getTempDirectoryPath('PROMPT_ANALYSIS');
       await fs.mkdir(tempAnalysisDir, { recursive: true }).catch(() => {});
       
-      // Simplified options - optimize for speed in hook mode
+      // Simplified options - optimize for speed in hook mode.
+      // maxThinkingTokens: 0 disables thinking regardless of the user's Claude
+      // Code settings (e.g. alwaysThinkingEnabled). Haiku does not support
+      // thinking, so without this the API returns 400 when the global setting
+      // is on. Analysis does not need thinking anyway; it only emits JSON.
       const queryOptions = {
         maxTurns: 1,                    // Single turn only
         model: selectedModel,           // Use selected model (haiku by default)
         disallowedTools: ['*'],         // No tools needed for JSON response
+        maxThinkingTokens: 0,           // Required for Haiku compatibility
         cwd: tempAnalysisDir            // Use temp directory to isolate analysis sessions
       };
       


### PR DESCRIPTION
Fixes #6. Set maxThinkingTokens: 0 in the analyze-prompt query options so the SDK's global thinking mode (driven by alwaysThinkingEnabled in settings.json) does not apply to Haiku-based analysis, which the API rejects with a 400 error.